### PR TITLE
Add `in` clause to Filters by meta

### DIFF
--- a/src/main/kotlin/kolbasa/consumer/filter/Filter.kt
+++ b/src/main/kotlin/kolbasa/consumer/filter/Filter.kt
@@ -433,6 +433,46 @@ object Filter {
         return IsNotNullCondition(property.name)
     }
 
+    /**
+     * PostgreSQL in operator.
+     *
+     * Usage is the same as in SQL:
+     * ```
+     * Meta::field in listOf(42)
+     * ```
+     * means `meta_field = ANY (42)`
+     */
+    infix fun <Meta : Any, T> KProperty1<Meta, T?>.`in`(values: Collection<T>): Condition<Meta> {
+        return InCondition(this.name, values)
+    }
+
+    /**
+     * PostgreSQL in operator.
+     *
+     * Usage is the same as in SQL:
+     * ```
+     * Meta::field in listOf(42)
+     * ```
+     * means `meta_field = ANY (42)`
+     */
+    infix fun <Meta : Any, T> KFunction1<Meta, T?>.`in`(values: Collection<T>): Condition<Meta> {
+        return InCondition(this.name, values)
+    }
+
+    /**
+     * PostgreSQL normal equality operator.
+     *
+     * Usage is the same as in SQL:
+     * ```
+     * Filter.eq(JavaField.of(...), ArrayList(42))
+     * ```
+     * means `meta_field = ANY (42)`
+     */
+    @JvmStatic
+    infix fun <Meta : Any, T> JavaField<Meta, T?>.`in`(values: Collection<T>): Condition<Meta> {
+        return InCondition(this.name, values)
+    }
+
     // -------------------------------------------------------------------------------------------
     @JvmStatic
     fun <Meta : Any> not(condition: Condition<Meta>): Condition<Meta> {

--- a/src/main/kotlin/kolbasa/consumer/filter/InCondition.kt
+++ b/src/main/kotlin/kolbasa/consumer/filter/InCondition.kt
@@ -1,0 +1,30 @@
+package kolbasa.consumer.filter
+
+import kolbasa.queue.Queue
+import kolbasa.queue.meta.MetaField
+import java.sql.PreparedStatement
+
+internal class InCondition<Meta : Any, T>(
+    private val fieldName: String,
+    private val values: Collection<T>
+) : Condition<Meta>() {
+
+    private lateinit var field: MetaField<Meta>
+
+    override fun internalToSqlClause(queue: Queue<*, Meta>): String {
+        if (!::field.isInitialized) {
+            field = findField(fieldName)
+        }
+
+        return "${field.dbColumnName} = ANY (?)"
+    }
+
+    override fun internalFillPreparedQuery(
+        queue: Queue<*, Meta>,
+        preparedStatement: PreparedStatement,
+        columnIndex: ColumnIndex
+    ) {
+        field.fillPreparedStatementForValues(preparedStatement, columnIndex.nextIndex(), values)
+    }
+
+}

--- a/src/main/kotlin/kolbasa/queue/meta/MetaField.kt
+++ b/src/main/kotlin/kolbasa/queue/meta/MetaField.kt
@@ -38,6 +38,15 @@ internal abstract class MetaField<Meta : Any>(
         fillPreparedStatementForValue(ps, columnIndex, propertyValue)
     }
 
+    fun fillPreparedStatementForValues(ps: PreparedStatement, columnIndex: Int, propertyValues: Collection<*>?) {
+        if (propertyValues == null) {
+            ps.setNull(columnIndex, sqlColumnType)
+        } else {
+            val sqlArray = ps.connection.createArrayOf(dbColumnType, propertyValues.toTypedArray())
+            ps.setArray(columnIndex, sqlArray)
+        }
+    }
+
     fun fillPreparedStatementForValue(ps: PreparedStatement, columnIndex: Int, propertyValue: Any?) {
         if (propertyValue == null) {
             ps.setNull(columnIndex, sqlColumnType)

--- a/src/test/kotlin/kolbasa/consumer/filter/FilterTest.kt
+++ b/src/test/kotlin/kolbasa/consumer/filter/FilterTest.kt
@@ -6,6 +6,7 @@ import kolbasa.consumer.filter.Filter.like
 import kolbasa.consumer.filter.Filter.eq
 import kolbasa.consumer.filter.Filter.greater
 import kolbasa.consumer.filter.Filter.greaterEq
+import kolbasa.consumer.filter.Filter.`in`
 import kolbasa.consumer.filter.Filter.isNotNull
 import kolbasa.consumer.filter.Filter.less
 import kolbasa.consumer.filter.Filter.lessEq
@@ -82,6 +83,11 @@ internal class FilterTest {
     @Test
     fun testNot() {
         assertIs<NotCondition<*>>(not(TestMeta::strValue eq "123"))
+    }
+
+    @Test
+    fun testIn() {
+        assertIs<InCondition<*, *>>(TestMeta::strValue `in` listOf("local"))
     }
 
     @Test

--- a/src/test/kotlin/kolbasa/consumer/filter/InConditionTest.kt
+++ b/src/test/kotlin/kolbasa/consumer/filter/InConditionTest.kt
@@ -1,0 +1,51 @@
+package kolbasa.consumer.filter
+
+import io.mockk.confirmVerified
+import io.mockk.mockk
+import io.mockk.verify
+import kolbasa.queue.PredefinedDataTypes
+import kolbasa.queue.Queue
+import kolbasa.queue.Searchable
+import kolbasa.queue.meta.MetaHelpers
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import java.sql.PreparedStatement
+
+internal class InConditionTest {
+
+    @Test
+    fun testToSql() {
+        val queue = Queue("test_queue", databaseDataType = PredefinedDataTypes.ByteArray, metadata = TestMeta::class.java)
+        val inExpression = InCondition<TestMeta, Int>(TestMeta::intValue.name, listOf(123))
+
+        val sql = inExpression.toSqlClause(queue)
+        assertEquals(MetaHelpers.generateMetaColumnName("intValue") + " = ANY (?)", sql)
+    }
+
+    @Test
+    fun testFillPreparedQuery() {
+        val queue = Queue("test_queue", databaseDataType = PredefinedDataTypes.ByteArray, metadata = TestMeta::class.java)
+        val inExpression = InCondition<TestMeta, Int>(TestMeta::intValue.name, listOf(123))
+
+        val preparedStatement = mockk<PreparedStatement>(relaxed = true)
+        val column = ColumnIndex()
+
+        // call
+        inExpression.toSqlClause(queue)
+        inExpression.fillPreparedQuery(queue, preparedStatement, column)
+
+        // check
+        verify {
+            preparedStatement.connection.createArrayOf("int", arrayOf(123))
+            preparedStatement.setArray(eq(1), any())
+        }
+        confirmVerified(preparedStatement)
+    }
+
+    companion object {
+        data class TestMeta(
+            @Searchable val intValue: Int,
+            val stringValue: String
+        )
+    }
+}


### PR DESCRIPTION
This pull request introduces support for the PostgreSQL `IN` operator in the `kolbasa` library. The changes include defining new methods for the `IN` operator, creating a corresponding condition class, updating the meta field class, and adding relevant tests.

### Support for PostgreSQL `IN` operator:

* [`src/main/kotlin/kolbasa/consumer/filter/Filter.kt`](diffhunk://#diff-1a60ab0aa12ea63f6a849d5af4c8d1067f5347919306bd2638f9bb2f0b048767R436-R475): Added new infix functions for the `IN` operator to handle `KProperty1`, `KFunction1`, and `JavaField` types.

### New condition class:

* [`src/main/kotlin/kolbasa/consumer/filter/InCondition.kt`](diffhunk://#diff-3885452327b671a644bd5824f0e032bbcab4727a049f7ccbc47679671a3b867eR1-R30): Created the `InCondition` class to represent the `IN` condition, including methods to generate SQL clauses and fill prepared statements.

### Meta field updates:

* [`src/main/kotlin/kolbasa/queue/meta/MetaField.kt`](diffhunk://#diff-bbd6b720cd4143664995e974f16d0791b10ba76330d1ba0162bca4718c666381R41-R49): Added the `fillPreparedStatementForValues` method to handle collections of values for the `IN` condition.

### Test updates:

* [`src/test/kotlin/kolbasa/consumer/filter/FilterTest.kt`](diffhunk://#diff-625e6d5ea73d57fc473252be8532f3b09311f7a8877358c8db1094d131d4e3c2R9): Added import for the new `IN` operator function and a test case to verify its functionality. [[1]](diffhunk://#diff-625e6d5ea73d57fc473252be8532f3b09311f7a8877358c8db1094d131d4e3c2R9) [[2]](diffhunk://#diff-625e6d5ea73d57fc473252be8532f3b09311f7a8877358c8db1094d131d4e3c2R88-R92)
* [`src/test/kotlin/kolbasa/consumer/filter/InConditionTest.kt`](diffhunk://#diff-3ccc4e995ff897714bcaf88b0c5646e07919c051006248e7ff2593a7501a82f5R1-R51): Added a new test class for `InCondition` to verify SQL clause generation and prepared statement filling.