### PR TITLE
Add node ID to OpenTelemetry spans for producer and consumer operations

### DIFF
--- a/src/main/kotlin/kolbasa/cluster/ClusterConsumer.kt
+++ b/src/main/kotlin/kolbasa/cluster/ClusterConsumer.kt
@@ -19,8 +19,8 @@ class ClusterConsumer(
         val latestState = cluster.getState()
 
         val consumer = latestState.getActiveConsumer(this) { nodeId, dataSource, shards ->
-            val c = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, shards)
-            DatabaseConsumer(dataSource, c)
+            val peer = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, shards)
+            DatabaseConsumer(nodeId, dataSource, peer)
         }
 
         // No active consumers at all:
@@ -46,8 +46,8 @@ class ClusterConsumer(
                 }
 
                 val consumer = latestState.getConsumer(this, node) { nodeId, dataSource ->
-                    val c = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, Shards.ALL_SHARDS)
-                    DatabaseConsumer(dataSource, c)
+                    val peer = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, Shards.ALL_SHARDS)
+                    DatabaseConsumer(nodeId, dataSource, peer)
                 }
 
                 consumer.delete(queue, ids)
@@ -55,8 +55,8 @@ class ClusterConsumer(
 
         if (deleted < messageIds.size) {
             val consumers = latestState.getConsumers(this) { nodeId, dataSource: DataSource ->
-                val c = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, Shards.ALL_SHARDS)
-                DatabaseConsumer(dataSource, c)
+                val peer = ConnectionAwareDatabaseConsumer(nodeId, consumerOptions, Shards.ALL_SHARDS)
+                DatabaseConsumer(nodeId, dataSource, peer)
             }
 
             consumers.forEach { consumer ->

--- a/src/main/kotlin/kolbasa/cluster/ClusterProducer.kt
+++ b/src/main/kotlin/kolbasa/cluster/ClusterProducer.kt
@@ -26,7 +26,7 @@ class ClusterProducer(
         val currentState = cluster.getState()
         val producer = currentState.getProducer(this, request.effectiveShard) { nodeId, dataSource ->
             val p = ConnectionAwareDatabaseProducer(nodeId, producerOptions)
-            DatabaseProducer(dataSource, p)
+            DatabaseProducer(nodeId, dataSource, p)
         }
 
         return producer.send(queue, request)

--- a/src/main/kotlin/kolbasa/consumer/connection/ConnectionAwareDatabaseConsumer.kt
+++ b/src/main/kotlin/kolbasa/consumer/connection/ConnectionAwareDatabaseConsumer.kt
@@ -39,7 +39,7 @@ class ConnectionAwareDatabaseConsumer internal constructor(
         // Do we need to read OT data?
         receiveOptions.readOpenTelemetryData = queue.queueTracing.readOpenTelemetryData()
 
-        return queue.queueTracing.makeConsumerCall {
+        return queue.queueTracing.makeConsumerCall(nodeId) {
             doRealReceive(connection, queue, limit, receiveOptions)
         }
     }

--- a/src/main/kotlin/kolbasa/consumer/datasource/DatabaseConsumer.kt
+++ b/src/main/kotlin/kolbasa/consumer/datasource/DatabaseConsumer.kt
@@ -8,12 +8,14 @@ import kolbasa.consumer.connection.ConnectionAwareDatabaseConsumer
 import kolbasa.utils.JdbcHelpers.useConnection
 import kolbasa.producer.Id
 import kolbasa.queue.Queue
+import kolbasa.schema.NodeId
 import javax.sql.DataSource
 
 /**
  * Default implementation of [Consumer]
  */
 class DatabaseConsumer internal constructor(
+    private val nodeId: NodeId,
     private val dataSource: DataSource,
     private val peer: ConnectionAwareConsumer
 ) : Consumer {
@@ -23,6 +25,7 @@ class DatabaseConsumer internal constructor(
         dataSource: DataSource,
         consumerOptions: ConsumerOptions = ConsumerOptions.DEFAULT
     ) : this(
+        nodeId = NodeId.EMPTY_NODE_ID,
         dataSource = dataSource,
         peer = ConnectionAwareDatabaseConsumer(consumerOptions)
     )
@@ -31,7 +34,7 @@ class DatabaseConsumer internal constructor(
         // Do we need to read OT data?
         receiveOptions.readOpenTelemetryData = queue.queueTracing.readOpenTelemetryData()
 
-        return queue.queueTracing.makeConsumerCall {
+        return queue.queueTracing.makeConsumerCall(nodeId) {
             dataSource.useConnection { peer.receive(it, queue, limit, receiveOptions) }
         }
     }

--- a/src/main/kotlin/kolbasa/producer/connection/ConnectionAwareDatabaseProducer.kt
+++ b/src/main/kotlin/kolbasa/producer/connection/ConnectionAwareDatabaseProducer.kt
@@ -34,7 +34,7 @@ class ConnectionAwareDatabaseProducer internal constructor(
         val partialInsert = ProducerSchemaHelpers.calculatePartialInsert(producerOptions, request.sendOptions)
 
         val (execution, result) = TimeHelper.measure {
-            queue.queueTracing.makeProducerCall(request) {
+            queue.queueTracing.makeProducerCall(nodeId, request) {
                 when (partialInsert) {
                     PartialInsert.PROHIBITED -> sendProhibited(connection, queue, approxStatsBytes, request)
                     PartialInsert.UNTIL_FIRST_FAILURE -> sendUntilFirstFailure(connection, queue, approxStatsBytes, request)

--- a/src/main/kotlin/kolbasa/producer/datasource/DatabaseProducer.kt
+++ b/src/main/kotlin/kolbasa/producer/datasource/DatabaseProducer.kt
@@ -9,6 +9,7 @@ import kolbasa.producer.SendResult
 import kolbasa.producer.connection.ConnectionAwareDatabaseProducer
 import kolbasa.producer.connection.ConnectionAwareProducer
 import kolbasa.queue.Queue
+import kolbasa.schema.NodeId
 import java.util.concurrent.CompletableFuture
 import javax.sql.DataSource
 
@@ -16,6 +17,7 @@ import javax.sql.DataSource
  * Default implementation of [Producer]
  */
 class DatabaseProducer internal constructor(
+    private val nodeId: NodeId,
     private val dataSource: DataSource,
     private val peer: ConnectionAwareProducer
 ): Producer {
@@ -25,12 +27,13 @@ class DatabaseProducer internal constructor(
         dataSource: DataSource,
         producerOptions: ProducerOptions = ProducerOptions.DEFAULT
     ) : this(
+        nodeId = NodeId.EMPTY_NODE_ID,
         dataSource = dataSource,
         peer = ConnectionAwareDatabaseProducer(producerOptions)
     )
 
     override fun <Data> send(queue: Queue<Data>, request: SendRequest<Data>): SendResult<Data> {
-        return queue.queueTracing.makeProducerCall(request) {
+        return queue.queueTracing.makeProducerCall(nodeId, request) {
             dataSource.useConnection { peer.send(it, queue, request) }
         }
     }

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerCall.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerCall.kt
@@ -1,0 +1,9 @@
+package kolbasa.stats.opentelemetry
+
+import kolbasa.consumer.Message
+import kolbasa.schema.NodeId
+
+internal class ConsumerCall<Data>(
+    val messages: List<Message<Data>>,
+    val nodeId: NodeId
+)

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerResponseAttributesGetter.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerResponseAttributesGetter.kt
@@ -1,0 +1,67 @@
+package kolbasa.stats.opentelemetry
+
+import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter
+
+internal class ConsumerResponseAttributesGetter<Data>(private val queueName: String) :
+    MessagingAttributesGetter<ConsumerCall<Data>, Unit> {
+
+    override fun getSystem(request: ConsumerCall<Data>?): String {
+        return "kolbasa"
+    }
+
+    override fun getDestination(request: ConsumerCall<Data>?): String {
+        return queueName
+    }
+
+    override fun isTemporaryDestination(request: ConsumerCall<Data>?): Boolean {
+        return false
+    }
+
+    override fun getConversationId(request: ConsumerCall<Data>?): String? {
+        return null
+    }
+
+    override fun getMessageId(request: ConsumerCall<Data>, response: Unit?): String? {
+        return if (request.messages.size == 1) {
+            request.messages[0].id.toString()
+        } else {
+            null
+        }
+    }
+
+    override fun getMessageHeader(request: ConsumerCall<Data>?, name: String?): List<String> {
+        if (request == null || name == null) {
+            return emptyList()
+        }
+
+        return request.messages.mapNotNull { it.openTelemetryData?.get(name) }
+    }
+
+    override fun getDestinationTemplate(request: ConsumerCall<Data>?): String? {
+        return null
+    }
+
+    override fun isAnonymousDestination(request: ConsumerCall<Data>?): Boolean {
+        return false
+    }
+
+    override fun getMessageBodySize(request: ConsumerCall<Data>?): Long? {
+        return null
+    }
+
+    override fun getMessageEnvelopeSize(request: ConsumerCall<Data>?): Long? {
+        return null
+    }
+
+    override fun getClientId(request: ConsumerCall<Data>?): String? {
+        return null
+    }
+
+    override fun getBatchMessageCount(request: ConsumerCall<Data>, response: Unit?): Long? {
+        return if (request.messages.size > 1) {
+            request.messages.size.toLong()
+        } else {
+            null
+        }
+    }
+}

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerSpanLinksExtractor.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerSpanLinksExtractor.kt
@@ -11,11 +11,11 @@ import kolbasa.consumer.Message
 internal class ConsumerSpanLinksExtractor<Data>(
     private val propagator: TextMapPropagator,
     private val extractor: TextMapGetter<Message<Data>>
-) : SpanLinksExtractor<List<Message<Data>>> {
+) : SpanLinksExtractor<ConsumerCall<Data>> {
 
-    override fun extract(spanLinks: SpanLinksBuilder, parentContext: Context, request: List<Message<Data>>) {
+    override fun extract(spanLinks: SpanLinksBuilder, parentContext: Context, request: ConsumerCall<Data>) {
         // Extract all context information from all messages and add them as links
-        request.forEach { req ->
+        request.messages.forEach { req ->
             val context = propagator.extract(Context.root(), req, extractor)
             spanLinks.addLink(Span.fromContext(context).spanContext)
         }

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/ContextToMessage.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/ContextToMessage.kt
@@ -3,16 +3,15 @@ package kolbasa.stats.opentelemetry
 import io.opentelemetry.context.propagation.TextMapGetter
 import io.opentelemetry.context.propagation.TextMapSetter
 import kolbasa.consumer.Message
-import kolbasa.producer.SendRequest
 
-internal class ContextToMessageSetter<Data> : TextMapSetter<SendRequest<Data>> {
+internal class ContextToMessageSetter<Data> : TextMapSetter<ProducerCall<Data>> {
 
-    override fun set(carrier: SendRequest<Data>?, key: String, value: String) {
+    override fun set(carrier: ProducerCall<Data>?, key: String, value: String) {
         if (carrier == null) {
             return
         }
 
-        carrier.addOpenTelemetryContext(key, value)
+        carrier.request.addOpenTelemetryContext(key, value)
     }
 }
 

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/EmptyQueueTracing.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/EmptyQueueTracing.kt
@@ -3,6 +3,7 @@ package kolbasa.stats.opentelemetry
 import kolbasa.consumer.Message
 import kolbasa.producer.SendRequest
 import kolbasa.producer.SendResult
+import kolbasa.schema.NodeId
 
 internal class EmptyQueueTracing<Data>: QueueTracing<Data> {
 
@@ -11,6 +12,7 @@ internal class EmptyQueueTracing<Data>: QueueTracing<Data> {
     }
 
     override fun makeProducerCall(
+        nodeId: NodeId,
         request: SendRequest<Data>,
         businessCall: () -> SendResult<Data>
     ): SendResult<Data> {
@@ -18,7 +20,7 @@ internal class EmptyQueueTracing<Data>: QueueTracing<Data> {
         return businessCall()
     }
 
-    override fun makeConsumerCall(businessCall: () -> List<Message<Data>>): List<Message<Data>> {
+    override fun makeConsumerCall(nodeId: NodeId, businessCall: () -> List<Message<Data>>): List<Message<Data>> {
         // default trivial implementation
         return businessCall()
     }

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/OpenTelemetryQueueTracing.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/OpenTelemetryQueueTracing.kt
@@ -1,16 +1,20 @@
 package kolbasa.stats.opentelemetry
 
 import io.opentelemetry.api.OpenTelemetry
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.AttributesBuilder
 import io.opentelemetry.context.Context
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessageOperation
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesExtractor
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingSpanNameExtractor
+import io.opentelemetry.instrumentation.api.instrumenter.AttributesExtractor
 import io.opentelemetry.instrumentation.api.instrumenter.Instrumenter
 import io.opentelemetry.instrumentation.api.instrumenter.SpanKindExtractor
 import io.opentelemetry.instrumentation.api.internal.InstrumenterUtil
 import kolbasa.consumer.Message
 import kolbasa.producer.SendRequest
 import kolbasa.producer.SendResult
+import kolbasa.schema.NodeId
 import java.time.Instant
 
 internal class OpenTelemetryQueueTracing<Data>(
@@ -18,10 +22,10 @@ internal class OpenTelemetryQueueTracing<Data>(
     openTelemetryConfig: OpenTelemetryConfig.Config
 ): QueueTracing<Data> {
 
-    private val producerInstrumenter: Instrumenter<SendRequest<Data>, SendResult<Data>> =
+    private val producerInstrumenter: Instrumenter<ProducerCall<Data>, SendResult<Data>> =
         buildProducerInstrumenter(openTelemetryConfig.openTelemetry, queueName)
 
-    private val consumerInstrumenter: Instrumenter<List<Message<Data>>, Unit> =
+    private val consumerInstrumenter: Instrumenter<ConsumerCall<Data>, Unit> =
         buildConsumerInstrumenter(openTelemetryConfig.openTelemetry, queueName)
 
     override fun readOpenTelemetryData(): Boolean {
@@ -29,37 +33,40 @@ internal class OpenTelemetryQueueTracing<Data>(
     }
 
     override fun makeProducerCall(
+        nodeId: NodeId,
         request: SendRequest<Data>,
         businessCall: () -> SendResult<Data>
     ): SendResult<Data> {
+        val producerCall = ProducerCall(request, nodeId)
         val parentContext = Context.current()
-        if (!producerInstrumenter.shouldStart(parentContext, request)) {
+        if (!producerInstrumenter.shouldStart(parentContext, producerCall)) {
             return businessCall()
         }
 
         // Start instrumenting
-        val context = producerInstrumenter.start(parentContext, request)
+        val context = producerInstrumenter.start(parentContext, producerCall)
         val response = try {
             context.makeCurrent().use {
                 businessCall()
             }
         } catch (e: Exception) {
-            producerInstrumenter.end(context, request, null, e)
+            producerInstrumenter.end(context, producerCall, null, e)
             throw e
         }
-        producerInstrumenter.end(context, request, response, null)
+        producerInstrumenter.end(context, producerCall, response, null)
 
         return response
     }
 
-    override fun makeConsumerCall(businessCall: () -> List<Message<Data>>): List<Message<Data>> {
+    override fun makeConsumerCall(nodeId: NodeId, businessCall: () -> List<Message<Data>>): List<Message<Data>> {
         val start = Instant.now()
         val result = businessCall()
         val end = Instant.now()
 
+        val consumerCall = ConsumerCall(result, nodeId)
         val parentContext = Context.current()
-        if (consumerInstrumenter.shouldStart(parentContext, result)) {
-            InstrumenterUtil.startAndEnd(consumerInstrumenter, parentContext, result, null, null, start, end)
+        if (consumerInstrumenter.shouldStart(parentContext, consumerCall)) {
+            InstrumenterUtil.startAndEnd(consumerInstrumenter, parentContext, consumerCall, null, null, start, end)
         }
 
         return result
@@ -68,37 +75,70 @@ internal class OpenTelemetryQueueTracing<Data>(
     private fun buildProducerInstrumenter(
         openTelemetry: OpenTelemetry,
         queueName: String
-    ): Instrumenter<SendRequest<Data>, SendResult<Data>> {
+    ): Instrumenter<ProducerCall<Data>, SendResult<Data>> {
         val sendRequestAttributesGetter = SendRequestAttributesGetter<Data>(queueName)
 
         val spanNameExtractor = MessagingSpanNameExtractor.create(sendRequestAttributesGetter, MessageOperation.PUBLISH)
 
-        val attributesExtractor = MessagingAttributesExtractor.builder(
+        val messagingAttributesExtractor = MessagingAttributesExtractor.builder(
             sendRequestAttributesGetter,
             MessageOperation.PUBLISH
         )
             .build()
 
-        return Instrumenter.builder<SendRequest<Data>, SendResult<Data>>(
+        val nodeIdAttributesExtractor = object : AttributesExtractor<ProducerCall<Data>, SendResult<Data>> {
+            override fun onStart(attributes: AttributesBuilder, parentContext: Context, request: ProducerCall<Data>) {
+                if (request.nodeId.id.isNotEmpty()) {
+                    attributes.put(NODE_ID_ATTRIBUTE_KEY, request.nodeId.id)
+                }
+            }
+
+            override fun onEnd(
+                attributes: AttributesBuilder,
+                context: Context,
+                request: ProducerCall<Data>,
+                response: SendResult<Data>?,
+                error: Throwable?
+            ) {}
+        }
+
+        return Instrumenter.builder<ProducerCall<Data>, SendResult<Data>>(
             openTelemetry,
             "kolbasa",
             spanNameExtractor
         )
-            .addAttributesExtractor(attributesExtractor)
+            .addAttributesExtractor(messagingAttributesExtractor)
+            .addAttributesExtractor(nodeIdAttributesExtractor)
             .buildProducerInstrumenter(ContextToMessageSetter())
     }
 
     private fun buildConsumerInstrumenter(
         openTelemetry: OpenTelemetry,
         queueName: String
-    ): Instrumenter<List<Message<Data>>, Unit> {
+    ): Instrumenter<ConsumerCall<Data>, Unit> {
         val getter = ConsumerResponseAttributesGetter<Data>(queueName)
         val operation = MessageOperation.RECEIVE
 
-        val attributesExtractor = MessagingAttributesExtractor.builder(getter, operation)
+        val messagingAttributesExtractor = MessagingAttributesExtractor.builder(getter, operation)
             .build()
 
-        return Instrumenter.builder<List<Message<Data>>, Unit>(
+        val nodeIdAttributesExtractor = object : AttributesExtractor<ConsumerCall<Data>, Unit> {
+            override fun onStart(attributes: AttributesBuilder, parentContext: Context, request: ConsumerCall<Data>) {
+                if (request.nodeId.id.isNotEmpty()) {
+                    attributes.put(NODE_ID_ATTRIBUTE_KEY, request.nodeId.id)
+                }
+            }
+
+            override fun onEnd(
+                attributes: AttributesBuilder,
+                context: Context,
+                request: ConsumerCall<Data>,
+                response: Unit?,
+                error: Throwable?
+            ) {}
+        }
+
+        return Instrumenter.builder<ConsumerCall<Data>, Unit>(
             openTelemetry,
             "kolbasa",
             MessagingSpanNameExtractor.create(getter, operation)
@@ -109,9 +149,12 @@ internal class OpenTelemetryQueueTracing<Data>(
                     ContextFromMessageGetter()
                 )
             )
-            .addAttributesExtractor(attributesExtractor)
+            .addAttributesExtractor(messagingAttributesExtractor)
+            .addAttributesExtractor(nodeIdAttributesExtractor)
             .buildInstrumenter(SpanKindExtractor.alwaysConsumer())
     }
 
-
+    companion object {
+        private val NODE_ID_ATTRIBUTE_KEY: AttributeKey<String> = AttributeKey.stringKey("kolbasa.node.id")
+    }
 }

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/ProducerCall.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/ProducerCall.kt
@@ -1,0 +1,9 @@
+package kolbasa.stats.opentelemetry
+
+import kolbasa.producer.SendRequest
+import kolbasa.schema.NodeId
+
+internal class ProducerCall<Data>(
+    val request: SendRequest<Data>,
+    val nodeId: NodeId
+)

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/QueueTracing.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/QueueTracing.kt
@@ -3,14 +3,15 @@ package kolbasa.stats.opentelemetry
 import kolbasa.consumer.Message
 import kolbasa.producer.SendRequest
 import kolbasa.producer.SendResult
+import kolbasa.schema.NodeId
 
 internal interface QueueTracing<Data> {
 
     fun readOpenTelemetryData(): Boolean
 
-    fun makeProducerCall(request: SendRequest<Data>, businessCall: () -> SendResult<Data>): SendResult<Data>
+    fun makeProducerCall(nodeId: NodeId, request: SendRequest<Data>, businessCall: () -> SendResult<Data>): SendResult<Data>
 
-    fun makeConsumerCall(businessCall: () -> List<Message<Data>>): List<Message<Data>>
+    fun makeConsumerCall(nodeId: NodeId, businessCall: () -> List<Message<Data>>): List<Message<Data>>
 
 }
 

--- a/src/main/kotlin/kolbasa/stats/opentelemetry/SendRequestAttributesGetter.kt
+++ b/src/main/kotlin/kolbasa/stats/opentelemetry/SendRequestAttributesGetter.kt
@@ -1,124 +1,58 @@
 package kolbasa.stats.opentelemetry
 
 import io.opentelemetry.instrumentation.api.incubator.semconv.messaging.MessagingAttributesGetter
-import kolbasa.consumer.Message
-import kolbasa.producer.SendRequest
 import kolbasa.producer.SendResult
 
 internal class SendRequestAttributesGetter<Data>(private val queueName: String) :
-    MessagingAttributesGetter<SendRequest<Data>, SendResult<Data>> {
+    MessagingAttributesGetter<ProducerCall<Data>, SendResult<Data>> {
 
-    override fun getSystem(request: SendRequest<Data>?): String {
+    override fun getSystem(request: ProducerCall<Data>?): String {
         return "kolbasa"
     }
 
-    override fun getDestination(request: SendRequest<Data>?): String {
+    override fun getDestination(request: ProducerCall<Data>?): String {
         return queueName
     }
 
-    override fun isTemporaryDestination(request: SendRequest<Data>?): Boolean {
+    override fun isTemporaryDestination(request: ProducerCall<Data>?): Boolean {
         return false
     }
 
-    override fun getConversationId(request: SendRequest<Data>?): String? {
+    override fun getConversationId(request: ProducerCall<Data>?): String? {
         return null
     }
 
-    override fun getMessageId(request: SendRequest<Data>?, response: SendResult<Data>?): String? {
+    override fun getMessageId(request: ProducerCall<Data>?, response: SendResult<Data>?): String? {
         return null
     }
 
-    override fun getMessageHeader(request: SendRequest<Data>?, name: String?): MutableList<String> {
+    override fun getMessageHeader(request: ProducerCall<Data>?, name: String?): MutableList<String> {
         return super.getMessageHeader(request, name)
     }
 
-    override fun getDestinationTemplate(request: SendRequest<Data>?): String? {
+    override fun getDestinationTemplate(request: ProducerCall<Data>?): String? {
         return null
     }
 
-    override fun isAnonymousDestination(request: SendRequest<Data>?): Boolean {
+    override fun isAnonymousDestination(request: ProducerCall<Data>?): Boolean {
         return false
     }
 
-    override fun getMessageBodySize(request: SendRequest<Data>?): Long? {
+    override fun getMessageBodySize(request: ProducerCall<Data>?): Long? {
         return null
     }
 
-    override fun getMessageEnvelopeSize(request: SendRequest<Data>?): Long? {
+    override fun getMessageEnvelopeSize(request: ProducerCall<Data>?): Long? {
         return null
     }
 
-    override fun getClientId(request: SendRequest<Data>?): String? {
+    override fun getClientId(request: ProducerCall<Data>?): String? {
         return null
     }
 
-    override fun getBatchMessageCount(request: SendRequest<Data>, response: SendResult<Data>?): Long? {
-        return if (request.data.size > 1) {
-            request.data.size.toLong()
-        } else {
-            null
-        }
-    }
-}
-
-internal class ConsumerResponseAttributesGetter<Data>(private val queueName: String) :
-    MessagingAttributesGetter<List<Message<Data>>, Unit> {
-
-    override fun getSystem(request: List<Message<Data>>?): String {
-        return "kolbasa"
-    }
-
-    override fun getDestination(request: List<Message<Data>>?): String {
-        return queueName
-    }
-
-    override fun isTemporaryDestination(request: List<Message<Data>>?): Boolean {
-        return false
-    }
-
-    override fun getConversationId(request: List<Message<Data>>?): String? {
-        return null
-    }
-
-    override fun getMessageId(request: List<Message<Data>>, response: Unit?): String? {
-        return if (request.size == 1) {
-            request[0].id.toString()
-        } else {
-            null
-        }
-    }
-
-    override fun getMessageHeader(request: List<Message<Data>>?, name: String?): List<String> {
-        if (request == null || name == null) {
-            return emptyList()
-        }
-
-        return request.mapNotNull { it.openTelemetryData?.get(name) }
-    }
-
-    override fun getDestinationTemplate(request: List<Message<Data>>?): String? {
-        return null
-    }
-
-    override fun isAnonymousDestination(request: List<Message<Data>>?): Boolean {
-        return false
-    }
-
-    override fun getMessageBodySize(request: List<Message<Data>>?): Long? {
-        return null
-    }
-
-    override fun getMessageEnvelopeSize(request: List<Message<Data>>?): Long? {
-        return null
-    }
-
-    override fun getClientId(request: List<Message<Data>>?): String? {
-        return null
-    }
-
-    override fun getBatchMessageCount(request: List<Message<Data>>, response: Unit?): Long? {
-        return if (request.size > 1) {
-            return request.size.toLong()
+    override fun getBatchMessageCount(request: ProducerCall<Data>, response: SendResult<Data>?): Long? {
+        return if (request.request.data.size > 1) {
+            request.request.data.size.toLong()
         } else {
             null
         }


### PR DESCRIPTION
This pull request introduces enhanced OpenTelemetry tracing by propagating the `NodeId` throughout the producer and consumer code paths, and by adding new OpenTelemetry attribute extractors for improved observability. The changes ensure that all relevant operations now include `NodeId` context in their tracing spans, and refactor the tracing infrastructure to use new wrapper classes (`ProducerCall`, `ConsumerCall`) for better attribute extraction.

**OpenTelemetry tracing improvements:**

* Refactored the OpenTelemetry tracing infrastructure to wrap producer and consumer operations in new `ProducerCall` and `ConsumerCall` classes, enabling the propagation and extraction of `NodeId` in tracing spans. (`src/main/kotlin/kolbasa/stats/opentelemetry/ProducerCall.kt` [[1]](diffhunk://#diff-02e0452150c0317ae93bc553f4cd0ec12de5aef15ef870949e79a6f77c004696R1-R9) `src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerCall.kt` [[2]](diffhunk://#diff-e06cba137104f269d45412367753e5e0d820cf434cd6cb532725f1e5d5985956R1-R9)
* Updated the OpenTelemetry instrumenters to extract and record the `NodeId` as a custom span attribute (`kolbasa.node.id`) for both producer and consumer spans. (`src/main/kotlin/kolbasa/stats/opentelemetry/OpenTelemetryQueueTracing.kt` [[1]](diffhunk://#diff-ffa83958fead2bffbb5d4b2b63ccb42610bd00f03069575886b3e1c35d2d90c0R4-R69) [[2]](diffhunk://#diff-ffa83958fead2bffbb5d4b2b63ccb42610bd00f03069575886b3e1c35d2d90c0L71-R141) [[3]](diffhunk://#diff-ffa83958fead2bffbb5d4b2b63ccb42610bd00f03069575886b3e1c35d2d90c0L112-R159)
* Added new attribute getter classes for consumer responses to improve the granularity and accuracy of OpenTelemetry span attributes. (`src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerResponseAttributesGetter.kt` [src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerResponseAttributesGetter.ktR1-R67](diffhunk://#diff-dcbee3c6c63795d2e7b7e5227a3cce962df8f2186e0802bad6e0c19589430c54R1-R67))

**API and method signature updates:**

* Updated `QueueTracing` and all related method signatures to accept and propagate `NodeId` for both producer and consumer calls, ensuring consistent context throughout the data flow. (`src/main/kotlin/kolbasa/consumer/datasource/DatabaseConsumer.kt` [[1]](diffhunk://#diff-bc6057848007ca19ccfd005649eb92ee0a69291b59c67258ace5b011088e9380R11-R18) [[2]](diffhunk://#diff-bc6057848007ca19ccfd005649eb92ee0a69291b59c67258ace5b011088e9380R28) [[3]](diffhunk://#diff-bc6057848007ca19ccfd005649eb92ee0a69291b59c67258ace5b011088e9380L34-R37); `src/main/kotlin/kolbasa/producer/datasource/DatabaseProducer.kt` [[4]](diffhunk://#diff-ed7299d7c8c1b75e024bae8148aee7b48b869db89375b1836cec36c70415167cR12-R20) [[5]](diffhunk://#diff-ed7299d7c8c1b75e024bae8148aee7b48b869db89375b1836cec36c70415167cR30-R36); `src/main/kotlin/kolbasa/cluster/ClusterConsumer.kt` [[6]](diffhunk://#diff-15d366d4f7351803394c141ff45fba2133867fcefd6bc7bb5da382dabc6c8552L22-R23) [[7]](diffhunk://#diff-15d366d4f7351803394c141ff45fba2133867fcefd6bc7bb5da382dabc6c8552L49-R59); `src/main/kotlin/kolbasa/cluster/ClusterProducer.kt` [[8]](diffhunk://#diff-a14a481415a2b42ae52b24fee06fe4e84456ca86cdde351a9fd19eb48c9ec0d9L29-R29); `src/main/kotlin/kolbasa/consumer/connection/ConnectionAwareDatabaseConsumer.kt` [[9]](diffhunk://#diff-2883c8a1b46a7132f26093db3d86982b5933dd3fc8a85fcbcb896d3871ee1446L42-R42); `src/main/kotlin/kolbasa/producer/connection/ConnectionAwareDatabaseProducer.kt` [[10]](diffhunk://#diff-d7e6cb0d7d2a8e4fa0d3c8614cd2c91acfd7d3d5c1b6f52b3649bce2262a2696L37-R37); `src/main/kotlin/kolbasa/stats/opentelemetry/EmptyQueueTracing.kt` [[11]](diffhunk://#diff-5eef8155d985958f8d7b9b8c377af9c8237c3543743d83be5f7a2ed354616c0fR6) [[12]](diffhunk://#diff-5eef8155d985958f8d7b9b8c377af9c8237c3543743d83be5f7a2ed354616c0fR15-R23)

**Tracing context propagation and extractor updates:**

* Refactored context propagation and span link extraction to use the new `ProducerCall` and `ConsumerCall` wrappers, updating all relevant OpenTelemetry extractor classes for compatibility. (`src/main/kotlin/kolbasa/stats/opentelemetry/ContextToMessage.kt` [[1]](diffhunk://#diff-a6128ef8d6e3206e16c02dd8093b7c56583dd8a3ed00ea9b31e0aa85bcae662bL6-R14) `src/main/kotlin/kolbasa/stats/opentelemetry/ConsumerSpanLinksExtractor.kt` [[2]](diffhunk://#diff-35d82ffa5d3ab763f6cbb83e9ad50e14fa5ff1361ade3ff460a05c77c8248ef1L14-R18)

These changes improve traceability and observability by ensuring that the `NodeId` is consistently available in all relevant OpenTelemetry spans, making it easier to diagnose distributed operations in a clustered environment.